### PR TITLE
Fix warning message for gcc 11 in CCcam.cfg

### DIFF
--- a/ncam-config.c
+++ b/ncam-config.c
@@ -1524,7 +1524,7 @@ struct ecmtw get_twin(ECM_REQUEST *er)
 #endif
 
 #if defined(MODULE_CCCAM) || defined(MODULE_NEWCAMD) || defined(MODULE_CAMD35) || defined(MODULE_RADEGAST)
-static int add_reader_from_line(char s[512], int type)
+static int add_reader_from_line(char s[510], int type)
 {
 	if(!s || !type) { return 0; }
 


### PR DESCRIPTION
In function 'add_reader_from_line',
    inlined from 'read_cccamcfg' at ncam-config.c:1833:12:
cc1: warning: 'add_reader_from_line.part.0' accessing 512 bytes in a region of size 510 [-Wstringop-overflow=]
ncam-config.c: In function 'read_cccamcfg':
cc1: note: referencing argument 1 of type 'char *'
ncam-config.c:1527:12: note: in a call to function 'add_reader_from_line.part.0'
 1527 | static int add_reader_from_line(char s[512], int type)