### PR TITLE
Fix not select Anticascading, errors:

### DIFF
--- a/ncam-config-account.c
+++ b/ncam-config-account.c
@@ -404,6 +404,8 @@ void class_fn(const char *token, char *value, void *setting, FILE *f)
 static void account_fixups_fn(void *var)
 {
 	struct s_auth *account = var;
+#endif
+#if defined(CS_ANTICASC)
 	if(account->ac_users < -1) { account->ac_users = DEFAULT_AC_USERS; }
 	if(account->ac_penalty < -1) { account->ac_penalty = DEFAULT_AC_PENALTY; }
 	if(account->acosc_max_ecms_per_minute < -1) { account->acosc_max_ecms_per_minute = -1; }
@@ -425,13 +427,15 @@ static void account_fixups_fn(void *var)
 			account->acosc_penalty_duration = (60 / account->acosc_max_ecms_per_minute);
 		}
 	}
-#ifdef CS_CACHEEX_AIO
+#endif
+#if defined(CS_CACHEEX_AIO)
 	// lgo-ctab -> lgo-ftab port
 	caidtab2ftab_add(&account->cacheex.localgenerated_only_in_caidtab, &account->cacheex.lg_only_in_tab);
 	caidtab_clear(&account->cacheex.localgenerated_only_in_caidtab);
 	caidtab2ftab_add(&account->cacheex.localgenerated_only_caidtab, &account->cacheex.lg_only_tab);
 	caidtab_clear(&account->cacheex.localgenerated_only_caidtab);
 #endif
+#if defined(CS_ANTICASC) || defined(CS_CACHEEX_AIO)
 }
 #endif
 


### PR DESCRIPTION
If Anticascading is not selected, the following errors are displayed, which have been corrected
please check it
..........................................
CC      ncam-config-account.c
ncam-config-account.c:407:14: error: no member named 'ac_users' in 'struct s_auth'
        if(account->ac_users < -1) { account->ac_users = DEFAULT_AC_USERS; }
           ~~~~~~~  ^
ncam-config-account.c:407:40: error: no member named 'ac_users' in 'struct s_auth'
        if(account->ac_users < -1) { account->ac_users = DEFAULT_AC_USERS; }
                                     ~~~~~~~  ^
ncam-config-account.c:408:14: error: no member named 'ac_penalty' in 'struct s_auth'
        if(account->ac_penalty < -1) { account->ac_penalty = DEFAULT_AC_PENALTY; }
           ~~~~~~~  ^
ncam-config-account.c:408:42: error: no member named 'ac_penalty' in 'struct s_auth'
        if(account->ac_penalty < -1) { account->ac_penalty = DEFAULT_AC_PENALTY; }
                                       ~~~~~~~  ^
ncam-config-account.c:409:14: error: no member named 'acosc_max_ecms_per_minute' in 'struct s_auth'
        if(account->acosc_max_ecms_per_minute < -1) { account->acosc_max_ecms_per_minute = -1; }
           ~~~~~~~  ^
ncam-config-account.c:409:57: error: no member named 'acosc_max_ecms_per_minute' in 'struct s_auth'
        if(account->acosc_max_ecms_per_minute < -1) { account->acosc_max_ecms_per_minute = -1; }
                                                      ~~~~~~~  ^
ncam-config-account.c:410:14: error: no member named 'acosc_max_active_sids' in 'struct s_auth'
        if(account->acosc_max_active_sids < -1) { account->acosc_max_active_sids = -1; }
           ~~~~~~~  ^
ncam-config-account.c:410:53: error: no member named 'acosc_max_active_sids' in 'struct s_auth'
        if(account->acosc_max_active_sids < -1) { account->acosc_max_active_sids = -1; }
                                                  ~~~~~~~  ^
ncam-config-account.c:411:14: error: no member named 'acosc_zap_limit' in 'struct s_auth'
        if(account->acosc_zap_limit < -1) { account->acosc_zap_limit = -1; }
           ~~~~~~~  ^
ncam-config-account.c:411:47: error: no member named 'acosc_zap_limit' in 'struct s_auth'
        if(account->acosc_zap_limit < -1) { account->acosc_zap_limit = -1; }
                                            ~~~~~~~  ^
ncam-config-account.c:412:14: error: no member named 'acosc_penalty' in 'struct s_auth'
        if(account->acosc_penalty < -1) { account->acosc_penalty = -1; }
           ~~~~~~~  ^
ncam-config-account.c:412:45: error: no member named 'acosc_penalty' in 'struct s_auth'
        if(account->acosc_penalty < -1) { account->acosc_penalty = -1; }
                                          ~~~~~~~  ^
ncam-config-account.c:413:14: error: no member named 'acosc_penalty_duration' in 'struct s_auth'
        if(account->acosc_penalty_duration < -1) { account->acosc_penalty_duration = -1; }
           ~~~~~~~  ^
ncam-config-account.c:413:54: error: no member named 'acosc_penalty_duration' in 'struct s_auth'
        if(account->acosc_penalty_duration < -1) { account->acosc_penalty_duration = -1; }
                                                   ~~~~~~~  ^
ncam-config-account.c:414:14: error: no member named 'acosc_delay' in 'struct s_auth'
        if(account->acosc_delay < -1) { account->acosc_delay = -1; }
           ~~~~~~~  ^
ncam-config-account.c:414:43: error: no member named 'acosc_delay' in 'struct s_auth'
        if(account->acosc_delay < -1) { account->acosc_delay = -1; }
                                        ~~~~~~~  ^
ncam-config-account.c:415:15: error: no member named 'acosc_penalty' in 'struct s_auth'
        if((account->acosc_penalty == 4) || ((cfg.acosc_penalty == 4) && (account->acosc_penalty == -1)))
            ~~~~~~~  ^
ncam-config-account.c:415:44: error: no member named 'acosc_penalty' in 'struct s_config'
        if((account->acosc_penalty == 4) || ((cfg.acosc_penalty == 4) && (account->acosc_penalty == -1)))
                                              ~~~ ^
ncam-config-account.c:415:77: error: no member named 'acosc_penalty' in 'struct s_auth'
        if((account->acosc_penalty == 4) || ((cfg.acosc_penalty == 4) && (account->acosc_penalty == -1)))
                                                                          ~~~~~~~  ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make[1]: *** [Makefile:501: build/armv7a-linux-androideabi24-stapi-libcurl-libusb/ncam-config-account.o] Error 1
make: *** [Makefile:453: all] Error 2