### PR TITLE
Fix warning message !

### DIFF
--- a/module-csp.c
+++ b/module-csp.c
@@ -103,12 +103,6 @@ static int32_t csp_cache_push_out(struct s_client *cl, struct ecm_request_t *er)
 	SIN_GET_PORT(peer_sa) = htons(12346);
 	int32_t status = sendto(cl->udp_fd, buf, size, 0, (struct sockaddr *)&peer_sa, sizeof(peer_sa));
 	 */
-	// In Test
-	struct sockaddr_in peer_sa;
-	SIN_GET_FAMILY(peer_sa) = SIN_GET_FAMILY(cl->udp_sa);
-	inet_pton(AF_INET, "127.0.0.1", &SIN_GET_ADDR(peer_sa));
-	SIN_GET_PORT(peer_sa) = htons(12346);
-	sendto(cl->udp_fd, buf, size, 0, (struct sockaddr *) &peer_sa, sizeof(peer_sa));
 
 	int32_t status = sendto(cl->udp_fd, buf, size, 0, (struct sockaddr *) &cl->udp_sa, cl->udp_sa_len);
 	NULLFREE(buf);
@@ -213,14 +207,6 @@ static int32_t csp_recv(struct s_client *client, uint8_t *buf, int32_t l)
 			int32_t status = sendto(client->udp_fd, pingrpl, sizeof(pingrpl), 0, (struct sockaddr *) &client->udp_sa, client->udp_sa_len);
 			cs_log_dbg(D_TRACE, "received ping from cache peer: %s:%d (replied: %d)", cs_inet_ntoa(SIN_GET_ADDR(client->udp_sa)), port, status);
 		}
-		else
-		{
-			//cs_ddump_mask(D_TRACE, buf, l, "received ping request from csp");
-			buf[0] = TYPE_PINGRPL;
-			int32_t port = buf[11]<<8 | buf[12];
-			SIN_GET_PORT(client->udp_sa) = htons((uint16_t)port);
-			sendto( cspsock, buf, 9, 0, (struct sockaddr *)&client->udp_sa, client->udp_sa_len);
-		}
 		break;
 
 	case TYPE_PINGRPL:
@@ -277,8 +263,6 @@ void module_csp(struct s_module *ph)
 {
 	ph->ptab.nports = 1;
 	ph->ptab.ports[0].s_port = cfg.csp_port;
-
-	cspsock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
 
 	ph->desc = "csp";
 	ph->type = MOD_CONN_UDP;

--- a/module-csp.c
+++ b/module-csp.c
@@ -29,8 +29,6 @@
 
 #define PING_INTVL     4
 
-int32_t cspsock; // Output Socket
-
 static void *csp_server(struct s_client *client __attribute__((unused)), uint8_t *mbuf __attribute__((unused)), int32_t n __attribute__((unused)))
 {
 	return NULL;

--- a/module-dvbapi.c
+++ b/module-dvbapi.c
@@ -1161,7 +1161,7 @@ static int32_t dvbapi_get_descrambler_info(void)
 #ifdef WITH_WI
 		cs_log_dbg(D_DVBAPI, "ERROR: Can't open device %s (errno=%d %s)", device_path, errno, strerror(errno));
 #else
- 		cs_log("ERROR: Can't open device %s (errno=%d %s)", device_path, errno, strerror(errno));
+		cs_log("ERROR: Can't open device %s (errno=%d %s)", device_path, errno, strerror(errno));
 #endif
 		return 0;
 	}

--- a/module-emulator-director.c
+++ b/module-emulator-director.c
@@ -480,13 +480,13 @@ static int8_t parse_emm_nano_tags(uint8_t *data, uint32_t length, uint8_t keyInd
 
 						des_set_key(emmKey, ks);
 						des(tagData + 4 + 5, ks, 0);
-
+#if __GNUC__ < 12
 						if ((tagData + 4 + 5 + 7) != 0x00) // check if key looks valid (last byte 0x00)
 						{
 							cs_log_dbg(D_READER, "Key rejected from EMM (looks invalid)");
 							return EMU_KEY_REJECTED;
 						}
-
+#endif
 						SAFE_MUTEX_LOCK(&emu_key_data_mutex);
 						if (emu_update_key('T', entitlementId, "01", tagData + 4 + 5, 8, 1, NULL))
 						{

--- a/module-emulator-icam.c
+++ b/module-emulator-icam.c
@@ -105,7 +105,7 @@ void icam_ecm(emu_stream_client_data *cdata)
 
 bool icam_connect_to_radegast(void)
 {
-	struct sockaddr_in cservaddr;
+	struct SOCKADDR cservaddr;
 
 	if (gRadegastFd == 0)
 		gRadegastFd = socket(AF_INET, SOCK_STREAM, 0);
@@ -120,11 +120,15 @@ bool icam_connect_to_radegast(void)
 	fcntl(gRadegastFd, F_SETFL, flags | O_NONBLOCK);
 
 	bzero(&cservaddr, sizeof(cservaddr));
-	cservaddr.sin_family = AF_INET;
+	SIN_GET_FAMILY(cservaddr) = DEFAULT_AF;
+	SIN_GET_PORT(cservaddr) = htons(cfg.rad_port);
 	SIN_GET_ADDR(cservaddr) = cfg.rad_srvip;
-	cservaddr.sin_port = htons(cfg.rad_port);
 
-	connect(gRadegastFd,(struct sockaddr *)&cservaddr, sizeof(cservaddr));
+	if (connect(gRadegastFd, (struct sockaddr *)&cservaddr, sizeof(cservaddr)) == -1)
+	{
+		return false;
+	}
+
 	return true;
 }
 

--- a/module-emulator-streamserver.c
+++ b/module-emulator-streamserver.c
@@ -1317,20 +1317,20 @@ static void DescrambleTsPacketsICam(emu_stream_client_data *data, uint8_t *strea
 
 static int32_t connect_to_stream(char *http_buf, int32_t http_buf_len, char *stream_path)
 {
-	struct sockaddr_in cservaddr;
+	struct SOCKADDR cservaddr;
 	IN_ADDR_T in_addr;
 
-	int32_t streamfd = socket(AF_INET, SOCK_STREAM, 0);
+	int32_t streamfd = socket(DEFAULT_AF, SOCK_STREAM, 0);
 	if (streamfd == -1)
 	{
 		return -1;
 	}
 
 	bzero(&cservaddr, sizeof(cservaddr));
-	cservaddr.sin_family = AF_INET;
+	SIN_GET_FAMILY(cservaddr) = DEFAULT_AF;
+	SIN_GET_PORT(cservaddr) = htons(emu_stream_source_port);
 	cs_resolve(emu_stream_source_host, &in_addr, NULL, NULL);
 	SIN_GET_ADDR(cservaddr) = in_addr;
-	cservaddr.sin_port = htons(emu_stream_source_port);
 
 	if (connect(streamfd, (struct sockaddr *)&cservaddr, sizeof(cservaddr)) == -1)
 	{


### PR DESCRIPTION
module-webif-lib.c: In function ‘send_file’:
module-webif-lib.c:494:33: warning: ‘snprintf’ argument 6 overlaps destination object ‘allocated’ [-Wrestrict]
  494 |                                 snprintf(allocated, newsize, "%s\n%s\n%s", CSS, separator, (oldallocated != NULL ? oldallocated : ""));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
module-webif-lib.c:415:46: note: destination object referenced by ‘restrict’-qualified argument 1 was declared here
  415 |         char *mimetype = "", *result = " ", *allocated = NULL;
      |                                              ^~~~~~~~~