### PR TITLE
Update LDFLAGS to work with binutils 2.40+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ LD = $(CROSS_DIR)$(CROSS)ld
 OBJCOPY = $(CROSS_DIR)$(CROSS)objcopy
 endif
 
-LDFLAGS = -Wl,--gc-sections
+LDFLAGS = -Wl,--gc-sections,-z noexecstack
 
 # The linker for powerpc have bug that prevents --gc-sections from working
 # Check for the linker version and if it matches disable --gc-sections


### PR DESCRIPTION
removed warnings/errors:
ld.bfd: warning: SoftCam.Key: missing .note.GNU-stack section implies executable stack ld.bfd: NOTE: This behaviour is deprecated and will be removed in a future version of the linker

... as mentioned here: https://board.streamboard.tv/forum/thread/46041-oscam-emu-laber-thread/?postID=614897#post614897