### PR TITLE
Fix module-dvbapi-stapi5.c error-sh4-stapi5

### DIFF
--- a/module-dvbapi-stapi5.c
+++ b/module-dvbapi-stapi5.c
@@ -135,136 +135,144 @@ static void stapi_off(void)
 
 int32_t stapi_open(void)
 {
-	uint32_t ErrorCode;
+    uint32_t ErrorCode;
+    struct dirent **entries = NULL;
+    int n, i;
 
-	DIR *dirp;
-	struct dirent entry, *dp = NULL;
-	struct stat buf;
-	int32_t i;
-	stapi_on = 1;
-	int32_t stapi_priority = 0;
+    stapi_on = 1;
+    int32_t stapi_priority = 0;
+    memset(dev_list, 0, sizeof(struct STDEVICE) * PTINUM);
 
-	memset(dev_list, 0, sizeof(struct STDEVICE)*PTINUM);
+    if (dvbapi_priority)
+    {
+        struct s_dvbapi_priority *p;
+        for (p = dvbapi_priority; p != NULL; p = p->next)
+        {
+            if (p->type == 's')
+            {
+                stapi_priority = 1;
+                break;
+            }
+        }
+    }
 
-	if(dvbapi_priority)
-	{
-		struct s_dvbapi_priority *p;
-		for(p = dvbapi_priority; p != NULL; p = p->next)
-		{
-			if(p->type == 's')
-			{
-				stapi_priority = 1;
-				break;
-			}
-		}
-	}
+    if (!stapi_priority)
+    {
+        cs_log("WARNING: no PTI devices defined, stapi disabled");
+        return 0;
+    }
 
-	if(!stapi_priority)
-	{
-		cs_log("WARNING: no PTI devices defined, stapi disabled");
-		return 0;
-	}
+    oscam_stapi5_GetRevision();
+    oscam_sttkd_GetRevision();
 
-	oscam_stapi5_GetRevision();
-	oscam_sttkd_GetRevision();
+    n = scandir(PROCDIR, &entries, NULL, NULL);
+    if (n == -1)
+    {
+        cs_log("scandir failed (errno=%d %s)", errno, strerror(errno));
+        return 0;
+    }
 
-	n = scandir(PROCDIR, &entries, NULL, NULL);
-	if (n==-1)
-	{
-		ics_log("scandir failed (errno=%d %s)", errno, strerror(errno));
-		return 0;
-	}
-	while(n--)
-	{
-		char pfad[cs_strlen(PROCDIR) + cs_strlen(dp->d_name) + 1];
-		cs_strncpy(pfad, PROCDIR, cs_strlen(PROCDIR) + 1);
-		cs_strncpy(pfad + cs_strlen(pfad), dp->d_name, cs_strlen(dp->d_name) + 1);
-		if(stat(pfad, &buf) != 0)
-			{ continue; }
+    for (i = 0; i < n; i++)
+    {
+        char pfad[cs_strlen(PROCDIR) + cs_strlen(entries[i]->d_name) + 1];
+        snprintf(pfad, sizeof(pfad), "%s%s", PROCDIR, entries[i]->d_name);
 
-		if(!(buf.st_mode & S_IFDIR && strncmp(entries[n]->d_name, ".", 1) != 0))
-			{ continue; }
+        struct stat buf;
+        if (stat(pfad, &buf) != 0)
+        {
+            continue;
+        }
 
-		int32_t do_open = 0;
-		struct s_dvbapi_priority *p;
+        if (!(buf.st_mode & S_IFDIR && strncmp(entries[i]->d_name, ".", 1) != 0))
+        {
+            continue;
+        }
 
-		for(p = dvbapi_priority; p != NULL; p = p->next)
-		{
-			if(p->type != 's') { continue; }
-			if(strcmp(entries[n]->d_name, entries[n]->devname) == 0)
-			{
-				do_open = 1;
-				break;
-			}
-		}
+        int32_t do_open = 0;
+        struct s_dvbapi_priority *p;
+        for (p = dvbapi_priority; p != NULL; p = p->next)
+        {
+            if (p->type != 's') { continue; }
+            if (strcmp(entries[i]->d_name, p->devname) == 0)
+            {
+                do_open = 1;
+                break;
+            }
+        }
 
-		if(!do_open)
-		{
-			cs_log("PTI: %s skipped", entries[n]->d_name);
-			continue;
-		}
+        if (!do_open)
+        {
+            cs_log("PTI: %s skipped", entries[i]->d_name);
+            continue;
+        }
 
-		ErrorCode = oscam_stapi5_Open(entries[n]->d_name, &dev_list[i].SessionHandle);
-		if(ErrorCode != 0)
-		{
-			cs_log("STPTI_Open ErrorCode: %d", ErrorCode);
-			continue;
-		}
+        ErrorCode = oscam_stapi5_Open(entries[i]->d_name, &dev_list[i].SessionHandle);
+        if (ErrorCode != 0)
+        {
+            cs_log("STPTI_Open ErrorCode: %d", ErrorCode);
+            continue;
+        }
 
-		//debug
-		//oscam_stapi_Capability(entries[n]->d_name);
+        cs_strncpy(dev_list[i].name, entries[i]->d_name, sizeof(dev_list[i].name));
+        cs_log("PTI: %s open %d", entries[i]->d_name, i);
 
-		cs_strncpy(dev_list[i].name, entries[n]->d_name, sizeof(dev_list[i].name));
-		cs_log("PTI: %s open %d", entries[n]->d_name, i);
+        ErrorCode = oscam_stapi5_SignalAllocate(dev_list[i].SessionHandle, &dev_list[i].SignalHandle);
+        if (ErrorCode != 0)
+        {
+            cs_log("SignalAllocate: ErrorCode: %d SignalHandle: %x", ErrorCode, dev_list[i].SignalHandle);
+        }
+    }
 
-		ErrorCode = oscam_stapi5_SignalAllocate(dev_list[i].SessionHandle, &dev_list[i].SignalHandle);
-		if(ErrorCode != 0)
-			{ cs_log("SignalAllocate: ErrorCode: %d SignalHandle: %x", ErrorCode, dev_list[i].SignalHandle); }
+    for (i = 0; i < n; i++)
+    {
+        free(entries[i]);
+    }
+    free(entries);
 
-		i++;
-		if(i >= PTINUM) { break; }
-	}
-	free(entries);
+    if (i == 0) { return 0; }
 
-	if(i == 0) { return 0; }
+    // Initialize TKD devices
+    uint8_t TKD_InstanceID = 0;
+    memset(&tkd_desc_info, 0, sizeof(tkd_desc_info[0]) * MAX_DESCRAMBLER);
+    for (TKD_InstanceID = 0; TKD_InstanceID < TKD_MAX_NUMBER; TKD_InstanceID++)
+    {
+        snprintf(TKD_DeviceName[TKD_InstanceID], sizeof(TKD_DeviceName), "TKD_%02d", TKD_InstanceID);
+        ErrorCode = oscam_sttkd_Open(TKD_DeviceName[TKD_InstanceID], &TKDHandle[TKD_InstanceID]);
+        if (ErrorCode != 0)
+        {
+            cs_log("oscam_sttkd_Open: DeviceName: %s, TKDHandle: 0x%08X, ErrorCode: %d", TKD_DeviceName[TKD_InstanceID], TKDHandle[TKD_InstanceID], ErrorCode);
+        }
+    }
 
-	uint8_t TKD_InstanceID = 0;
-	memset(&tkd_desc_info, 0, sizeof(tkd_desc_info[0]) * MAX_DESCRAMBLER);
+    SAFE_MUTEX_INIT(&filter_lock, NULL);
 
-	for(TKD_InstanceID = 0; TKD_InstanceID < TKD_MAX_NUMBER; TKD_InstanceID++)
-	{
-			/* Generate the device name dynamically based upon the Instance ID */
-			snprintf(TKD_DeviceName[TKD_InstanceID], sizeof(TKD_DeviceName), "TKD_%02d", TKD_InstanceID);
+    for (i = 0; i < PTINUM; i++)
+    {
+        if (dev_list[i].SessionHandle == 0)
+        {
+            continue;
+        }
 
-			ErrorCode = oscam_sttkd_Open(TKD_DeviceName[TKD_InstanceID], &TKDHandle[TKD_InstanceID]);
-			if(ErrorCode != 0)
-				cs_log("oscam_sttkd_Open: DeviceName: %s, TKDHandle: 0x%08X, ErrorCode: %d", TKD_DeviceName[TKD_InstanceID], TKDHandle[TKD_InstanceID], ErrorCode);
-	}
+        struct read_thread_param *para = malloc(sizeof(struct read_thread_param));
+        if (!para)
+        {
+            return 0;
+        }
+        para->id = i;
+        para->cli = cur_client();
 
-	SAFE_MUTEX_INIT(&filter_lock, NULL);
+        int32_t ret = start_thread("stapi read", stapi_read_thread, (void *)para, &dev_list[i].thread, 1, 0);
+        if (ret)
+        {
+            free(para);
+            return 0;
+        }
+    }
 
-	for(i = 0; i < PTINUM; i++)
-	{
-		if(dev_list[i].SessionHandle == 0)
-			{ continue; }
+    atexit(stapi_off);
 
-		struct read_thread_param *para;
-		if(!cs_malloc(&para, sizeof(struct read_thread_param)))
-			{ return 0; }
-		para->id = i;
-		para->cli = cur_client();
-
-		int32_t ret = start_thread("stapi read", stapi_read_thread, (void *)para, &dev_list[i].thread, 1, 0);
-		if(ret)
-		{
-			return 0;
-		}
-	}
-
-	atexit(stapi_off);
-
-	cs_log("liboscam_stapi5 v.%s initialized", oscam_stapi5_LibVersion());
-	return 1;
+    cs_log("liboscam_stapi5 v.%s initialized", oscam_stapi5_LibVersion());
+    return 1;
 }
 
 int32_t stapi_activate_section_filter(int32_t fd, uint8_t *filter, uint8_t *mask)


### PR DESCRIPTION
CC      module-dvbapi-stapi5.c
module-dvbapi-stapi5.c: In function 'stapi_open':
module-dvbapi-stapi5.c:171:2: error: 'n' undeclared (first use in this function)
module-dvbapi-stapi5.c:171:2: note: each undeclared identifier is reported only once for each function it appears in
module-dvbapi-stapi5.c:171:24: error: 'entries' undeclared (first use in this function)
module-dvbapi-stapi5.c:174:3: warning: implicit declaration of function 'ics_log' [-Wimplicit-function-declaration]
module-dvbapi-stapi5.c:141:16: warning: unused variable 'entry' [-Wunused-variable]
module-dvbapi-stapi5.c:140:7: warning: unused variable 'dirp' [-Wunused-variable]
make[1]: *** [Makefile:578: build/sh4-stapi5-libcurl/module-dvbapi-stapi5.o] Error 1
make: *** [Makefile:525: all] Error 2