### PR TITLE
Fix Build Error for Smargo Smartreader Selection

### DIFF
--- a/csctapi/ifd_smartreader.c
+++ b/csctapi/ifd_smartreader.c
@@ -900,7 +900,7 @@ static int32_t smartreader_set_latency_timer(struct s_reader *reader, uint16_t  
 }
 
 #if defined(__CYGWIN__)
-static WINAPI read_callback(struct libusb_transfer *transfer)
+static WINAPI void read_callback(struct libusb_transfer *transfer)
 {
 #else
 static void read_callback(struct libusb_transfer *transfer)


### PR DESCRIPTION
csctapi/ifd_smartreader.c:903:15: error: return type defaults to ‘int’ [-Wimplicit-int]
  903 | static WINAPI read_callback(struct libusb_transfer *transfer)
      |               ^~~~~~~~~~~~~
csctapi/ifd_smartreader.c: In function ‘read_callback’:
csctapi/ifd_smartreader.c:930:33: error: ‘return’ with no value, in function returning non-void [-Wreturn-mismatch]
  930 |                                 return;
      |                                 ^~~~~~
csctapi/ifd_smartreader.c:903:15: note: declared here
  903 | static WINAPI read_callback(struct libusb_transfer *transfer)
      |               ^~~~~~~~~~~~~
make[1]: *** [Makefile:609: build/x86_64-pc-cygwin-ssl-libcurl-libusb-pcsc-libdvbcsa/csctapi/ifd_smartreader.o] Error 1
make: *** [Makefile:556: all] Error 2