### PR TITLE
Fix fclose() call in detect_valgrind function

### DIFF
--- a/ncam.c
+++ b/ncam.c
@@ -1630,8 +1630,8 @@ static void detect_valgrind(void)
 				break;
 			}
 		}
+		fclose(f);
 	}
-	fclose(f);
 #endif
 }
 


### PR DESCRIPTION
Closing a file that was not successfully opened, will result in undefined behavior. 

Fixed by moving the `fclose()` inside the` if (f)` condition