### PR TITLE
Forcing the card to use a specific CAID

### DIFF
--- a/module-emulator-ecmdb.h
+++ b/module-emulator-ecmdb.h
@@ -18,7 +18,7 @@ typedef enum {
 
 // ECM entry (RAM mode only)
 typedef struct ecmdb_entry {
-    uint8_t *ecm_data;
+    size_t ecm_offset;
     uint8_t cw[ECMDB_CW_LEN];
     uint16_t ecm_len;
     uint32_t hash;            // xxHash32

--- a/reader-conax.c
+++ b/reader-conax.c
@@ -151,6 +151,7 @@ static int32_t conax_card_init(struct s_reader *reader, ATR *newatr)
 						0xff, 0xfb, 0x00, 0x00, 0x09, 0x04, 0x0b, 0x00, 0xe0, 0x30, 0x2b };
 
 	uint8_t cardver = 0;
+	uint16_t card_caid = 0; // CAID override: store card's original CAID
 
 	get_hist;
 	if((hist_size < 4) || (memcmp(hist, "0B00", 4)))
@@ -169,7 +170,19 @@ static int32_t conax_card_init(struct s_reader *reader, ATR *newatr)
 				break;
 
 			case 0x28:
-				reader->caid = (cta_res[i + 2] << 8) | cta_res[i + 3];
+				card_caid = (cta_res[i + 2] << 8) | cta_res[i + 3];
+				
+				// use configured CAID if specified, otherwise use card's CAID
+				if(reader->ctab.ctnum > 0 && reader->ctab.ctdata[0].caid != 0)
+				{
+					reader->caid = reader->ctab.ctdata[0].caid;
+					rdr_log(reader, "configured %04X (card %04X)", reader->caid, card_caid);
+				}
+				else
+				{
+					reader->caid = card_caid;
+				}
+				break;
 		}
 	}
 
@@ -490,6 +503,8 @@ static int32_t conax_card_info(struct s_reader *reader)
 	uint32_t cxclass = 0;
 
 	cs_clear_entitlement(reader); // reset the entitlements
+	
+	uint16_t caid_to_use = reader->caid; // use configured/overridden CAID for entitlements
 
 	for(type = 0; type < 2; type++)
 	{
@@ -524,7 +539,7 @@ static int32_t conax_card_info(struct s_reader *reader)
 											txt[type], ++n, provid, chid, pdate, pdate + 16, trim(provname));
 
 									// add entitlements to list
-									cs_add_entitlement(reader, reader->caid, b2ll(4, reader->prid[0]),
+									cs_add_entitlement(reader, caid_to_use, b2ll(4, reader->prid[0]),
 											provid, cxclass, start_t, end_t, type + 1, 1);
 
 									k = 0;
@@ -547,7 +562,7 @@ static int32_t conax_card_info(struct s_reader *reader)
 							txt[type], ++n, provid, chid, pdate, pdate + 16, trim(provname));
 
 					// add entitlements to list
-					cs_add_entitlement(reader, reader->caid, b2ll(4, reader->prid[0]),
+					cs_add_entitlement(reader, caid_to_use, b2ll(4, reader->prid[0]),
 							provid, cxclass, start_t, end_t, type + 1, 1);
 				}
 			}


### PR DESCRIPTION
Some modified Conax cards require a specific CAID for proper ECM handling