### PR TITLE
dvbapi: add support for more net send clients

### DIFF
--- a/module-dvbapi.h
+++ b/module-dvbapi.h
@@ -461,6 +461,7 @@ typedef struct demux_s
 	int8_t           decodingtries;                  // -1 = first run
 	struct timeb     decstart;
 	struct timeb     decend;
+	uint32_t         msgid;
 } DEMUXTYPE;
 
 typedef struct s_streampid


### PR DESCRIPTION
* connections established with client_proto_version = 3 and extended_cw_api >= 1 can now also process CW_ALGO_CSA_ALT independently
* proper handling of dvbapi_ioctl commands in this case
* fix rerouting of msgid back to client
* support each videoguard caid
* make sure ecm.info is created

* this will support upcoming e2 softCSA as replacement for ncam streamrelay via libdvbcsa